### PR TITLE
"release.bat" must not include the .Net runtime into the executable.

### DIFF
--- a/release.bat
+++ b/release.bat
@@ -8,7 +8,7 @@ echo.
 echo Building for configuration: %CONFIG%
 echo.
 
-dotnet publish StreamDeckSimHub.Plugin\StreamDeckSimHub.Plugin.csproj -c %CONFIG% -r win-x64 --self-contained
+dotnet publish StreamDeckSimHub.Plugin\StreamDeckSimHub.Plugin.csproj -c %CONFIG% -r win-x64
 
 if exist build rmdir /s /q build
 if exist build goto :endFailure


### PR DESCRIPTION
Closes #24