### PR TITLE
The Property Server now sends strings with special characters base64 encoded

### DIFF
--- a/StreamDeckSimHub.Plugin/SimHub/PropertyType.cs
+++ b/StreamDeckSimHub.Plugin/SimHub/PropertyType.cs
@@ -74,6 +74,13 @@ public static class PropertyTypeEx
             }
             case PropertyType.String:
             {
+                if (propertyValue.StartsWith("{base64}"))
+                {
+                    // Decode base64 string.
+                    var base64String = propertyValue[8..];
+                    var bytes = Convert.FromBase64String(base64String);
+                    return System.Text.Encoding.UTF8.GetString(bytes);
+                }
                 return propertyValue;
             }
             case PropertyType.Object:


### PR DESCRIPTION
Otherwise the value is corrupted.

Issue #191