### PR TITLE
Installer: Next version of Stream Deck plugin requires Property Server >= 1.12.0

### DIFF
--- a/StreamDeckSimHub.Installer/Tools/Configuration.cs
+++ b/StreamDeckSimHub.Installer/Tools/Configuration.cs
@@ -26,6 +26,6 @@ namespace StreamDeckSimHub.Installer.Tools
         public static readonly string SimHubDefaultInstallFolder = Path.Combine("C:", "Program Files (x86)", "SimHub");
 
         public const string SimHubPluginUrl = "https://github.com/pre-martin/SimHubPropertyServer";
-        public static readonly Version RequiredSimHubPluginVersion = new Version(1, 9, 6);
+        public static readonly Version RequiredSimHubPluginVersion = new Version(1, 12, 0);
     }
 }


### PR DESCRIPTION
Reason: https://github.com/pre-martin/SimHubPropertyServer/issues/53